### PR TITLE
set the html from youtube url as trusted content using

### DIFF
--- a/app/assets/app.js
+++ b/app/assets/app.js
@@ -21590,7 +21590,7 @@ CONFIG = {
     $scope.onReady();
   }])
 
-  .controller('VideoCtrl', ['$appYoutubeSearcher','$compile', '$rootScope', '$routeParams', '$scope',function($youtube, $compile, $rootScope, $params, $scope) {
+  .controller('VideoCtrl', ['$appYoutubeSearcher','$compile', '$rootScope', '$routeParams', '$scope', '$sce', function($youtube, $compile, $rootScope, $params, $scope, $sce) {
     var id = $params.id;
     $youtube.findVideo(id, true, function(id, video) {
       $scope.video_id = id;
@@ -21604,6 +21604,10 @@ CONFIG = {
         $scope.related = videos;
         if(!$scope.$$phase) $scope.$apply();
       });
+      
+      $scope.trustSrc = function(src) {
+        return $sce.trustAsResourceUrl(src);
+      }
     });
   }]);
 ;angular.module('App.Filters', []).

--- a/app/scripts/controllers/controllers.js
+++ b/app/scripts/controllers/controllers.js
@@ -72,7 +72,7 @@ angular.module('App.Controllers', [])
     $scope.onReady();
   }])
 
-  .controller('VideoCtrl', ['$appYoutubeSearcher','$compile', '$rootScope', '$routeParams', '$scope',function($youtube, $compile, $rootScope, $params, $scope) {
+  .controller('VideoCtrl', ['$appYoutubeSearcher','$compile', '$rootScope', '$routeParams', '$scope', '$sce', function($youtube, $compile, $rootScope, $params, $scope, $sce) {
     var id = $params.id;
     $youtube.findVideo(id, true, function(id, video) {
       $scope.video_id = id;
@@ -86,5 +86,9 @@ angular.module('App.Controllers', [])
         $scope.related = videos;
         if(!$scope.$$phase) $scope.$apply();
       });
+      
+      $scope.trustSrc = function(src) {
+        return $sce.trustAsResourceUrl(src);
+      }
     });
   }]);

--- a/app/templates/views/videos/show_tpl.html
+++ b/app/templates/views/videos/show_tpl.html
@@ -21,7 +21,7 @@
     <h1>{{ video.title }}</h1>
   </header>
   <div class="app-youtube-embed">
-    <iframe width="900" height="500" src="{{ video.embedUrl }}" frameborder="0" allowfullscreen></iframe>
+    <iframe type="text/html" width="900" height="500" ng-src="{{ trustSrc(video.embedUrl) }}" allowfullscreen frameborder="0"></iframe>
   </div>
 
   <div class="app-youtube-related">


### PR DESCRIPTION
Using the app for a while I have been getting this error when I tried to show any video:

```
Error: [$interpolate:interr] Can't interpolate: {{ video.embedUrl }}
Error: [$sce:insecurl] Blocked loading resource from url not allowed by $sceDelegate policy.  URL: http://www.youtube.com/embed/ersEb9vTX3Y?autoplay=1
http://errors.angularjs.org/1.2.1/$sce/insecurl?p0=http%3A%2F%2Fwww.youtube.com%2Fembed%2FersEb9vTX3Y%3Fautoplay%3D1
http://errors.angularjs.org/1.2.1/$interpolate/interr?p0=%7B%7B%20video.emb…253A%252F%252Fwww.youtube.com%252Fembed%252FersEb9vTX3Y%253Fautoplay%253D1
  at http://localhost:8888/assets/app.js:78:12
  at $interpolate.fn (http://localhost:8888/assets/app.js:8087:26)
  at attrInterpolatePreLinkFn (http://localhost:8888/assets/app.js:6420:30)
  at nodeLinkFn (http://localhost:8888/assets/app.js:6104:13)
  at compositeLinkFn (http://localhost:8888/assets/app.js:5536:15)
  at compositeLinkFn (http://localhost:8888/assets/app.js:5539:13)
  at compositeLinkFn (http://localhost:8888/assets/app.js:5539:13)
  at publicLinkFn (http://localhost:8888/assets/app.js:5444:30)
  at http://localhost:8888/assets/app.js:20995:15
  at publicLinkFn (http://localhost:8888/assets/app.js:5443:29) 
```

One possible solution for this issue is injecting $sce service inside VideoCtrl controller and making the embedded HTML code from Youtube URLs trusted content inside the show_tpl.html
