### PR TITLE
Make postinstall command work for Windows and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/matsko/YOM-AngularJS-Testing-Article"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower install"
+    "postinstall": "node node_modules/bower/bin/bower install"
   },
   "homepage": "https://github.com/yearofmoo/YOM-AngularJS-Testing-Article",
   "devDependencies": {


### PR DESCRIPTION
Useful for people who are on Windows too.
This should fix #28.
